### PR TITLE
Move dell_os9 tasks into a dedicated file

### DIFF
--- a/roles/common/tasks/dell_os9.yaml
+++ b/roles/common/tasks/dell_os9.yaml
@@ -1,0 +1,17 @@
+- name: Set hostname
+  dellemc.os9.os9_config:
+    lines:
+      - hostname {{ inventory_hostname }}
+
+- name: Disable telnet server
+  dellemc.os9.os9_config:
+    lines:
+      - no ip telnet enable
+
+- name: Update VLANs
+  dellemc.os9.os9_config:
+    lines:
+      - name {{ item.value.name }}
+      - description {{ item.value.description }}
+    parents: ["interface vlan {{ item.key }}"]
+  loop: "{{ lookup('ansible.builtin.dict', vlans | get_vlan_dict(group_names), wantlist=True) }}"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,21 +1,3 @@
 ---
-- name: Set hostname
-  dellemc.os9.os9_config:
-    lines:
-      - hostname {{ inventory_hostname }}
-  when: ansible_network_os == "dellemc.os9.os9"
-
-- name: Disable telnet server
-  dellemc.os9.os9_config:
-    lines:
-      - no ip telnet enable
-  when: ansible_network_os == "dellemc.os9.os9"
-
-- name: Update VLANs
-  dellemc.os9.os9_config:
-    lines:
-      - name {{ item.value.name }}
-      - description {{ item.value.description }}
-    parents: ["interface vlan {{ item.key }}"]
-  loop: "{{ lookup('ansible.builtin.dict', vlans | get_vlan_dict(group_names), wantlist=True) }}"
+- include_tasks: dell_os9.yaml
   when: ansible_network_os == "dellemc.os9.os9"

--- a/roles/snmp/tasks/dell_os9.yaml
+++ b/roles/snmp/tasks/dell_os9.yaml
@@ -1,0 +1,6 @@
+---
+- name: Enable SNMP
+  dellemc.os9.os9_config:
+    lines:
+      - snmp-server community private rw
+      - snmp-server community public ro

--- a/roles/snmp/tasks/main.yml
+++ b/roles/snmp/tasks/main.yml
@@ -1,7 +1,3 @@
 ---
-- name: Enable SNMP
-  dellemc.os9.os9_config:
-    lines:
-      - snmp-server community private rw
-      - snmp-server community public ro
+- include_tasks: dell_os.yaml
   when: ansible_network_os == "dellemc.os9.os9"


### PR DESCRIPTION
By moving tasks into per-os task files, we only need a single `when`
conditional in `tasks/main.yaml` for each role. This makes the tasks easier
to read and avoids accidents when someone forgets to include the necessary
`when` conditional on an individual task.
