### PR TITLE
Rewrite get_vlan_dict filter using a dict comprehension

### DIFF
--- a/filter_plugins/vlan_dict.py
+++ b/filter_plugins/vlan_dict.py
@@ -1,17 +1,11 @@
 def get_vlan_dict(vlan_dict, group_names):
-    out = {}
+    return {
+        vlan: vlan_dict[vlan]
+        for vlan in vlan_dict
+        if any(group in group_names for group in vlan_dict[vlan]["switches"])
+    }
 
-    for key in vlan_dict.keys():
-        # check hostnames
-        enabled_hosts = vlan_dict[key]["switches"]
-
-        for group in enabled_hosts:
-            if group in group_names:
-                # this host should have this vlan
-                out[key] = vlan_dict[key]
-    
-    return out
 
 class FilterModule(object):
     def filters(self):
-        return { 'get_vlan_dict': get_vlan_dict }
+        return {"get_vlan_dict": get_vlan_dict}


### PR DESCRIPTION
We can make the get_vlan_dict filter substantially more compact by making
use of a dict comprehension [1].

[1]: https://docs.python.org/3/tutorial/datastructures.html#dictionaries
