### PR TITLE
Add validate role for jsonschema validation of input data

### DIFF
--- a/roles/validate/defaults/main.yaml
+++ b/roles/validate/defaults/main.yaml
@@ -1,0 +1,1 @@
+jsonschema_draft: draft7

--- a/roles/validate/files/interface_configuration.yaml
+++ b/roles/validate/files/interface_configuration.yaml
@@ -1,0 +1,45 @@
+$id: https://massopen.cloud/schemas/interface_configuration.yaml
+title: Interface Configuration
+type: object
+patternProperties:
+  "^[0-9]+(/[0-9]+)+$":
+    $ref: "#/$defs/interface"
+additionalProperties: false
+$defs:
+  interface:
+    type: object
+    additionalProperties: false
+    properties:
+      description:
+        type: string
+      admin:
+        type: string
+        enum:
+          - up
+          - down
+      untagged_vlan:
+        type: integer
+      tagged_vlans:
+        type: array
+        items:
+          type: integer
+      mtu:
+        type: integer
+        minimum: 0
+      fanout:
+        type: string
+        enum:
+          - single
+          - dual
+          - quad
+      fanout_speed:
+        type: string
+        enum:
+          - 10G
+          - 25G
+          - 40G
+          - 100G
+      ip4:
+        type: string
+      ip6:
+        type: string

--- a/roles/validate/files/vlan_configuration.yaml
+++ b/roles/validate/files/vlan_configuration.yaml
@@ -1,0 +1,23 @@
+$id: https://massopen.cloud/schemas/vlan_configuration.yaml
+title: VLAN Configuration
+type: object
+patternProperties:
+  "^[0-9]+$":
+    $ref: "#/$defs/vlan"
+additionalProperties: false
+$defs:
+  vlan:
+    type: object
+    properties:
+      name:
+        type: string
+      description:
+        type: string
+      switches:
+        type: array
+        items:
+          type: string
+    required:
+      - name
+      - description
+      - switches

--- a/roles/validate/tasks/main.yaml
+++ b/roles/validate/tasks/main.yaml
@@ -1,0 +1,25 @@
+- name: Load schema
+  set_fact:
+    schema: >-
+      {{
+        lookup('ansible.builtin.file', schema_path) | from_yaml
+      }}
+
+- name: Validate data
+  set_fact:
+    validation_errors: >-
+      {{
+      lookup('ansible.utils.validate', data, schema,
+      engine='ansible.utils.jsonschema',
+      draft=jsonschema_draft)
+      }}
+
+- when: validation_errors
+  block:
+    - name: Display validation errors
+      debug:
+        var: validation_errors
+
+    - name: Fail due to validation errors
+      fail:
+        msg: Failing due to validation errors.

--- a/site.yml
+++ b/site.yml
@@ -1,6 +1,35 @@
 ---
+- name: Validate configuration
+  hosts: all
+  gather_facts: false
+  tags: [validate]
+
+  # Abort the playbook if any host fails validation
+  any_errors_fatal: true
+
+  tasks:
+    - name: Validate vlan configuration
+      run_once: true
+      include_role:
+        name: validate
+      vars:
+        schema_path: vlan_configuration.yaml
+        data: "{{ vlans }}"
+
+    - name: Validate interface configuration
+      when: interfaces is defined
+      include_role:
+        name: validate
+        apply:
+          delegate_to: localhost
+      vars:
+        schema_path: interface_configuration.yaml
+        data: "{{ interfaces }}"
+
 - hosts: all
   connection: network_cli
-  roles:
-    - role: common
-    - role: snmp
+  tasks:
+    - include_role:
+        name: common
+    - include_role:
+        name: snmp


### PR DESCRIPTION
This commits adds the `validate` role, which contains jsonschemas for the
vlan configuration in `group_vars/all/vlans.yaml` and the per-host
interface configuration as well as tasks for performing data validation.

The schemas cover most of but not all of the validations performed by
the erstwhile `validation.py` script. In particular, the schemas do not
forbid mixing L2  configuration (`tagged_vlans`, `untagged_vlan`) with L3
configurastion (`ip4`, `ip6`).