### PR TITLE
Adding Production VLANs

### DIFF
--- a/group_vars/all/vlans.yaml
+++ b/group_vars/all/vlans.yaml
@@ -108,7 +108,7 @@ vlans:
     switches:
   267:
     name: "MOC-RESEARCH-CEPH-EXTRA"
-    description: "****"
+    description: "MOC research ceph students"
     switches:
       - oct_data
   270:
@@ -134,7 +134,7 @@ vlans:
       - oct_data
   280:
     name: "MOC-MAAS-NIC1"
-    description: "****"
+    description: "MAAS Internal Network 2"
     switches:
       - oct_data
   300:
@@ -145,11 +145,6 @@ vlans:
   301:
     name: "UNITY-MGMT"
     description: "Unity Cluster at UMass Mgmt Net"
-    switches:
-      - oct_data
-  308:
-    name: "MOC-JIANZZHA"
-    description: "****"
     switches:
       - oct_data
   500:
@@ -305,6 +300,10 @@ vlans:
     description: "AL2S VLAN 3109 for Fabric"
     switches:
       - oct_hub
+  3800:
+    name: "CSAIL-3800"
+    description: "CSAIL 3800"
+    switches:
   3801:
     name: "CSAIL-3801"
     description: "CSAIL - ESI Floating IP"
@@ -320,7 +319,3 @@ vlans:
     description: "CSAIL MaaS"
     switches:
       - oct_data
-  3808:
-    name: "****"
-    description: "Public IPs****"
-    switches:

--- a/group_vars/all/vlans.yaml
+++ b/group_vars/all/vlans.yaml
@@ -1,17 +1,281 @@
----
 vlans:
-  100:
-    name: "VLAN 100"
-    description: "This is the description of example vlan 100"
+  10:
+    name: "CSAIL-MAIN"
+    description: "Openstack public facing services (horizon, keystone)"
     switches:
-      - oct_tors
-  101:
-    name: "VLAN 101"
-    description: "This is the description of example vlan 101"
+      - oct_data
+  57:
+    name: "UMA-57"
+    description: "UMass VLAN 57 Public IPs for Chameleon"
     switches:
-      - oct_tors
-  102:
-    name: "VLAN 102"
-    description: "hello world"
+      - oct_data
+  84:
+    name: "UMA-84"
+    description: "UMass VLAN 84 Public IPs for CloudLab"
     switches:
-      - oct_tors
+      - oct_data
+  86:
+    name: "UMA-86"
+    description: "UMass VLAN 86 Public IPs for Fabric"
+  105:
+    name: "MOC-BU-PUBLIC"
+    description: "Public IPs from BU"
+    switches:
+      - oct_data
+  127:
+    name: "MOC-NEU-PUBLIC"
+    description: "NEU Public IP for infrastructure"
+    switches:
+      - oct_data
+  201:
+    name: "MOC-FOREMAN"
+    description: "Foreman Provisioning. SNMP for OpenStack and Ceph"
+    switches:
+      - oct_data
+  202:
+    name: "MOC-OPENSTACK-INTERNAL"
+    description: "OpenStack internal API"
+    switches:
+  203:
+    name: "MOC-OPENSTACK-TENANT"
+    description: "OpenStack tenant network"
+    switches:
+  204:
+    name: "MOC-GENERAL"
+    description: "Intranet (routable to internet). SNMP for client nodes."
+    switches:
+      - oct_data
+  205:
+    name: "MOC-GLUSTER"
+    description: "Gluster/VM migration - oVirt"
+    switches:
+  206:
+    name: "MOC-OPENSTACK-ISOLATION"
+    description: "OStack isolation native vlan for trunk only ports"
+    switches:
+  207:
+    name: "MOC-SWITCH-MGMT"
+    description: "For OCT/UMass Switch Management"
+    switches:
+      - oct_data
+      - oct_mgmt
+  208:
+    name: "ESI-CONTROL-PLANE"
+    description: "ESI control plane"
+    switches:
+      - oct_data
+  209:
+    name: "OCP-PROD-PROVISIONING"
+    description: "Openshift Internal (Baremetal 4.x)"
+    switches:
+      - oct_data
+  210:
+    name: "MOC-NFS-ZERO-CLUSTER"
+    description: "NFS for zero cluster"
+    switches:
+      - oct_data
+  211:
+    name: "MOC-NESE"
+    description: "New England Storage Exchange (NESE)"
+    switches:
+      - oct_data
+  212:
+    name: "OCP-STAGING-INTERNAL"
+    description: "Openshift Staging Internal (ocp-staging)"
+    switches:
+  213:
+    name: "MOC-PROD-CEPH-ISCSI"
+    description: "Ceph Cluster iSCSI"
+    switches:
+      - oct_data
+  249:
+    name: "CEPH-INTERNAL"
+    description: "Ceph Cluster (internal)"
+    switches:
+  250:
+    name: "MOC-PROD-CEPH"
+    description: "Ceph public (for clients)"
+    switches:
+      - oct_data
+  252:
+    name: "MOC-RESEARCH-CEPH"
+    description: "****"
+    switches:
+      - oct_data
+  259:
+    name: "STAGING-FOREMAN"
+    description: "Staging - Foreman"
+    switches:
+  267:
+    name: "MOC-RESEARCH-CEPH-EXTRA"
+    description: "****"
+    switches:
+      - oct_data
+  270:
+    name: "STAGING-INTERNAL"
+    description: "Staging - Internal API"
+    switches:
+  271:
+    name: "STAGING-TENANT"
+    description: "Staging - Tenant Network"
+    switches:
+  272:
+    name: "STAGING-PUBLIC"
+    description: "Staging - Public Network"
+    switches:
+  273:
+    name: "STAGING-OSSTACK"
+    description: "Staging - OS Stack isolation for trunk only ports"
+    switches:
+  277:
+    name: "MOC-MAAS"
+    description: "****"
+    switches:
+      - oct_data
+  280:
+    name: "MOC-MAAS-NIC1"
+    description: "****"
+    switches:
+      - oct_data
+  300:
+    name: "UNITY-INTERNAL"
+    description: "****"
+    switches:
+      - oct_data
+  301:
+    name: "UNITY-MGMT"
+    description: "****"
+    switches:
+      - oct_data
+  308:
+    name: "MOC-JIANZZHA"
+    description: "****"
+    switches:
+      - oct_data
+  500:
+    name: "MOC_BMI"
+    description: "****"
+    switches:
+      - oct_data
+  501:
+    name: "MOC-BMI"
+    description: "****"
+    switches:
+      - oct_data
+  701:
+    name: "ENGAGE1-FOREMAN"
+    description: "Foreman Provisioning. SNMP for OpenStack and Ceph	"
+    switches:
+  702:
+    name: "ENGAGE1-OPENSTACK-INTERNAL"
+    description: "OpenStack internal API"
+    switches:
+  703:
+    name: "ENGAGE1-OPENSTACK-TENANT"
+    description: "OpenStack tenant network"
+    switches:
+  704:
+    name: "ENGAGE1-INTRANET"
+    description: "Intranet (routable to internet). SNMP for client nodes."
+    switches:
+  749:
+    name: "ENGAGE1-CEPH"
+    description: "Ceph Cluster (internal)"
+    switches:
+  750:
+    name: "ENGAGE1-CEPH-PUBLIC"
+    description: "Ceph public (for clients)"
+    switches:
+  910:
+    name: "CLOUDLAB-OBM"
+    description: "CloudLab IPMI Network"
+    switches:
+      - CL-SW-TORS
+      - oct_hub
+      - oct_mgmt
+  911:
+    name: "OCT-MOC-OBM"
+    description: "For OCT/UMass nodes IPMI"
+    switches:
+      - oct_mgmt
+  912:
+    name: "OCT-MOC"
+    description: "For OCT/UMass nodes IPMI for operate first"
+    switches:
+      - oct_mgmthub
+  930:
+    name: "OCT-SWMGMT"
+    description: "Switch management network for OCT"
+    switches:
+      - oct_mgmt
+  931:
+    name: "CHAMELEON-OBM"
+    description: "Chameleon management network"
+    switches:
+      - OCT8-SW-MGMT
+  950:
+    name: "UMA-NESE"
+    description: "NESE BGP VLAN for UMass"
+    switches:
+  1000:
+    name: "CHAMELEON-INTERNAL"
+    description: "Chameleon Internal Network"
+    switches:
+      - OCT8-SW-TORS
+  1001:
+    name: "CHAMELEON-NEUTRON"
+    description: "Chameleon neutron provisioning"
+    switches:
+      - OCT8-SW-TORS
+  1004:
+    name: "KUMO-INTRANET"
+    description: "Intranet (routable to internet). SNMP for client nodes."
+    switches:
+      - oct_data
+  2470:
+    name: "NERC-FLOATING-201"
+    description: "*eth4: floating ip (vlan 201) - tenant public IPs"
+    switches:
+  2471:
+    name: "NERC-EXTERNAL-200"
+    description: "*eth3: external network (vlan 200) - public API / endpoints	"
+    switches:
+  2472:
+    name: "NERC-INTERNAL-101"
+    description: "eth0.101: internal api (vlan 101) - internal to node"
+    switches:
+  2473:
+    name: "NERC-PRIVATE-102"
+    description: "eth0.102: tenant private (vlan 102) - VMs sit here, private network/VXLAN"
+    switches:
+  2476:
+    name: "NERC-ADMIN-100"
+    description: "NERC-Admin network 1->eth0:provisioning network(vlan 100)-deploying images/DHCP> PAT out"
+    switches:
+  2477:
+    name: "NERC-OBM"
+    description: "NERC - OBM/MGMT Network 1 -> eth1: management/ipmi - undercloud to DRAC/BMC 10.255"
+    switches:
+  2478:
+    name: "NERC-STORAGE-103"
+    description: "eth2: storage (vlan 103) - ceph/jumboframe? 10.255	"
+    switches:
+  3801:
+    name: "CSAIL-3801"
+    description: "CSAIL Floating IP 1"
+    switches:
+      - oct_data
+  3802:
+    name: "CSAIL-3802"
+    description: "CSAIL Floating IP 2"
+    switches:
+      - oct_data
+  3803:
+    name: "CSAIL-3803"
+    description: "CSAIL Floating IP 3"
+    switches:
+      - oct_data
+  3808:
+    name: "****"
+    description: "Public IPs****"
+    switches:

--- a/group_vars/all/vlans.yaml
+++ b/group_vars/all/vlans.yaml
@@ -164,7 +164,7 @@ vlans:
       - oct_data
   701:
     name: "ENGAGE1-FOREMAN"
-    description: "Foreman Provisioning. SNMP for OpenStack and Ceph	"
+    description: "Foreman Provisioning. SNMP for OpenStack and Ceph"
     switches:
   702:
     name: "ENGAGE1-OPENSTACK-INTERNAL"

--- a/group_vars/all/vlans.yaml
+++ b/group_vars/all/vlans.yaml
@@ -238,7 +238,7 @@ vlans:
     switches:
   2471:
     name: "NERC-EXTERNAL-200"
-    description: "*eth3: external network (vlan 200) - public API / endpoints	"
+    description: "*eth3: external network (vlan 200) - public API / endpoints"
     switches:
   2472:
     name: "NERC-INTERNAL-101"
@@ -258,7 +258,7 @@ vlans:
     switches:
   2478:
     name: "NERC-STORAGE-103"
-    description: "eth2: storage (vlan 103) - ceph/jumboframe? 10.255	"
+    description: "eth2: storage (vlan 103) - ceph/jumboframe? 10.255"
     switches:
   3801:
     name: "CSAIL-3801"

--- a/group_vars/all/vlans.yaml
+++ b/group_vars/all/vlans.yaml
@@ -1,7 +1,7 @@
 vlans:
   10:
     name: "CSAIL-MAIN"
-    description: "Openshift public facing services (horizon, keystone)"
+    description: "Various Openshift clusters"
     switches:
       - oct_data
   57:

--- a/group_vars/all/vlans.yaml
+++ b/group_vars/all/vlans.yaml
@@ -1,7 +1,7 @@
 vlans:
   10:
     name: "CSAIL-MAIN"
-    description: "Openstack public facing services (horizon, keystone)"
+    description: "Openshift public facing services (horizon, keystone)"
     switches:
       - oct_data
   57:
@@ -129,7 +129,7 @@ vlans:
     switches:
   277:
     name: "MOC-MAAS"
-    description: "****"
+    description: "MAAS Internal Network"
     switches:
       - oct_data
   280:
@@ -154,11 +154,6 @@ vlans:
       - oct_data
   500:
     name: "MOC_BMI"
-    description: "****"
-    switches:
-      - oct_data
-  501:
-    name: "MOC-BMI"
     description: "****"
     switches:
       - oct_data
@@ -262,7 +257,7 @@ vlans:
     switches:
   3801:
     name: "CSAIL-3801"
-    description: "CSAIL Floating IP 1"
+    description: "CSAIL - ESI Floating IP"
     switches:
       - oct_data
   3802:
@@ -272,7 +267,7 @@ vlans:
       - oct_data
   3803:
     name: "CSAIL-3803"
-    description: "CSAIL Floating IP 3"
+    description: "CSAIL MaaS"
     switches:
       - oct_data
   3808:

--- a/group_vars/all/vlans.yaml
+++ b/group_vars/all/vlans.yaml
@@ -99,7 +99,7 @@ vlans:
       - oct_data
   252:
     name: "MOC-RESEARCH-CEPH"
-    description: "****"
+    description: "MOC Research Ceph"
     switches:
       - oct_data
   259:
@@ -139,12 +139,12 @@ vlans:
       - oct_data
   300:
     name: "UNITY-INTERNAL"
-    description: "****"
+    description: "Unity Cluster at UMass Internal Net"
     switches:
       - oct_data
   301:
     name: "UNITY-MGMT"
-    description: "****"
+    description: "Unity Cluster at UMass Mgmt Net"
     switches:
       - oct_data
   308:
@@ -154,7 +154,7 @@ vlans:
       - oct_data
   500:
     name: "MOC_BMI"
-    description: "****"
+    description: "MOC BMI Provisioning"
     switches:
       - oct_data
   701:

--- a/group_vars/all/vlans.yaml
+++ b/group_vars/all/vlans.yaml
@@ -17,6 +17,8 @@ vlans:
   86:
     name: "UMA-86"
     description: "UMass VLAN 86 Public IPs for Fabric"
+    switches:
+      - oct_data
   105:
     name: "MOC-BU-PUBLIC"
     description: "Public IPs from BU"

--- a/group_vars/all/vlans.yaml
+++ b/group_vars/all/vlans.yaml
@@ -255,6 +255,56 @@ vlans:
     name: "NERC-STORAGE-103"
     description: "eth2: storage (vlan 103) - ceph/jumboframe? 10.255"
     switches:
+  3100:
+    name: "AL2S-3100"
+    description: "AL2S VLAN 3100 for Fabric"
+    switches:
+      - oct_hub
+  3101:
+    name: "AL2S-3101"
+    description: "AL2S VLAN 3101 for Fabric"
+    switches:
+      - oct_hub
+  3102:
+    name: "AL2S-3102"
+    description: "AL2S VLAN 3102 for Fabric"
+    switches:
+      - oct_hub
+  3103:
+    name: "AL2S-3103"
+    description: "AL2S VLAN 3103 for Fabric"
+    switches:
+      - oct_hub
+  3104:
+    name: "AL2S-3104"
+    description: "AL2S VLAN 3104 for Fabric"
+    switches:
+      - oct_hub
+  3105:
+    name: "AL2S-3105"
+    description: "AL2S VLAN 3105 for Fabric"
+    switches:
+      - oct_hub
+  3106:
+    name: "AL2S-3106"
+    description: "AL2S VLAN 3106 for Fabric"
+    switches:
+      - oct_hub
+  3107:
+    name: "AL2S-3107"
+    description: "AL2S VLAN 3107 for Fabric"
+    switches:
+      - oct_hub
+  3108:
+    name: "AL2S-3108"
+    description: "AL2S VLAN 3108 for Fabric"
+    switches:
+      - oct_hub
+  3109:
+    name: "AL2S-3109"
+    description: "AL2S VLAN 3109 for Fabric"
+    switches:
+      - oct_hub
   3801:
     name: "CSAIL-3801"
     description: "CSAIL - ESI Floating IP"

--- a/hosts
+++ b/hosts
@@ -9,6 +9,7 @@ OCT-MHUB-1      ansible_host=10.80.1.11
 OCT-MHUB-2      ansible_host=10.80.1.12
 
 [oct_tors]
+CL-SW-TORS      ansible-host=10.80.2.1
 OCT1-SW-TORS    ansible_host=10.80.2.11
 OCT2-SW-TORS    ansible_host=10.80.2.21
 OCT3-SW-TORS-A  ansible_host=10.80.2.31
@@ -34,6 +35,14 @@ OCT5-SW-CTRL    ansible_host=10.80.2.54
 OCT7-SW-CTRL    ansible_host=10.80.2.73
 OCT8-SW-CTRL    ansible_host=10.80.2.83
 OCT9-SW-HYB     ansible_host=10.80.2.93
+
+[oct_data:children]
+oct_hub
+oct_tors
+
+[oct_mgmt:children]
+oct_mgmthub
+oct_tors_mgmt
 
 [oct:children]
 oct_hub


### PR DESCRIPTION
First step in adding our production config is the VLAN info. That is included in this PR. There are a number of fields with stars `*` in them, which as of yet do not have information. We'll use this PR to fill everything in. Not every VLAN in the file is actually in an OCT switch so the switch field is empty, but we can keep them in for when we add additional switch drivers/make this repo more responsible for other parts of the network.

Marking this as a draft while we work on it.