### PR TITLE
Bugfixing some issues with the prod config

### DIFF
--- a/filter_plugins/dell_os9.py
+++ b/filter_plugins/dell_os9.py
@@ -503,6 +503,9 @@ def os9_getIntfConfig(intf_dict, sw_config, label_map, vlan_map, type):
 
                             vlan_cmd.append((["interface Vlan " + str(cur_vlan)], "no " + assign_type + " " + sw_label))
 
+                            # delete from vlan map so future methods don't touch this
+                            vlan_map[intf_label][assign_type].remove(cur_vlan)
+
         if "stp-edge" in intf and intf["stp-edge"]:
             # define edge-port for every stp protocol in os9 (only live one will take effect)
             out.append("spanning-tree rstp edge-port")

--- a/filter_plugins/dell_os9.py
+++ b/filter_plugins/dell_os9.py
@@ -1,5 +1,3 @@
-import warnings
-
 #
 # Helper methods
 #
@@ -665,6 +663,10 @@ def os9_getVlanConfig(intf_dict, label_map, vlan_map, vlan_names):
     out_tuple = []
 
     for vlan in vlan_names:
+        if int(vlan) == 1:
+            # skip default vlan
+            continue
+
         out = []
 
         out.append("name " + vlan_names[vlan]["name"])
@@ -732,7 +734,6 @@ def os9_getConfiguration(sw_facts, intf_dict, vlan_dict, po_dict, vlan_names):
     po_cfg = os9_getIntfConfig(po_dict, sw_config, label_map, type = "port-channel")
     out += po_cfg
 
-    # TODO, this step can probably be done more efficienty combined with above
     lacp_cfg = os9_getLACPConfig(po_dict, sw_config, label_map)
     out += lacp_cfg
 

--- a/filter_plugins/vlan_dict.py
+++ b/filter_plugins/vlan_dict.py
@@ -2,7 +2,8 @@ def get_vlan_dict(vlan_dict, group_names):
     return {
         vlan: vlan_dict[vlan]
         for vlan in vlan_dict
-        if any(group in group_names for group in vlan_dict[vlan]["switches"])
+        if type(vlan_dict[vlan]["switches"]) == list and \
+            any(group in group_names for group in vlan_dict[vlan]["switches"])
     }
 
 


### PR DESCRIPTION
Now that we are adding production configurations, I am finding a bit more edge cases in the filter code. This PR addresses:

* If an interface is changed from L3 to L2 while already being assigned to a VLAN, the playbook would fail because os9 expected the interface to be removed from all VLANs prior to changing status.
* Fixed the edge case where a switch doesn't have any L3 vlan interfaces, the playbook would fail
* Fixed explicitly adding interfaces to the default vlan, which would cause the playbook to fail.