### PR TITLE
Add vlan 214 to the port-channel between OCT-MCORE switch and the OCT…

### DIFF
--- a/host_vars/OCT-CORE-1/port-channels.yaml
+++ b/host_vars/OCT-CORE-1/port-channels.yaml
@@ -95,6 +95,7 @@ port_channels:
       - 84
       # MOC
       - 207
+      - 214
       # Unity
       - 301
       # MGMT

--- a/host_vars/OCT-CORE-2/port-channels.yaml
+++ b/host_vars/OCT-CORE-2/port-channels.yaml
@@ -95,6 +95,7 @@ port_channels:
       - 84
       # MOC
       - 207
+      - 214
       # Unity
       - 301
       # MGMT


### PR DESCRIPTION
…-CORE switches

Note that OCT-MCORE is not managed by this repo at this time.

This VLAN is needed for the undercloud host on OCT-MCORE to provision the overclouds on the CORE switches.