### PR TITLE
Migrating Cisco switch in R4-PA-C02 to the dell switch in R4-PA-C02

### DIFF
--- a/gather_hw_info.yaml
+++ b/gather_hw_info.yaml
@@ -1,0 +1,9 @@
+---
+- name: Deployment Playbook
+  hosts: all
+  connection: network_cli
+  gather_facts: false
+  vars:
+    diff_only: false
+  roles:
+    - hwinfo

--- a/host_vars/MOC-MCORE-1/interfaces.yaml
+++ b/host_vars/MOC-MCORE-1/interfaces.yaml
@@ -1,8 +1,12 @@
 interfaces:
   GigabitEthernet 1/1:
-    state: "down"
+    state: "up"
+    portmode: "access"
+    untagged: 930
   GigabitEthernet 1/2:
-    state: "down"
+    state: "up"
+    portmode: "access"
+    untagged: 930
   GigabitEthernet 1/3:
     state: "down"
   GigabitEthernet 1/4:

--- a/host_vars/MOC-R4PAC02-SW-TORS/interfaces.yaml
+++ b/host_vars/MOC-R4PAC02-SW-TORS/interfaces.yaml
@@ -1,48 +1,153 @@
 interfaces:
   twentyFiveGigE 1/1:
-    state: "down"
+    state: "up"
+    portmode: access
+    untagged: 249
+    stp:
+      edgeport: true
+      bpduguard: true
   twentyFiveGigE 1/2:
-    state: "down"
+    state: "up"
+    portmode: trunk
+    tagged:
+      - 201
+      - 250
+      - 277
+    stp:
+      edgeport: true
+      bpduguard: true
   twentyFiveGigE 1/3:
-    state: "down"
+    state: "up"
+    portmode: access
+    untagged: 249
+    stp:
+      edgeport: true
+      bpduguard: true
   twentyFiveGigE 1/4:
-    state: "down"
+    state: "up"
+    portmode: trunk
+    tagged:
+      - 201
+      - 250
+      - 277
+    stp:
+      edgeport: true
+      bpduguard: true
   twentyFiveGigE 1/5:
-    state: "down"
+    state: "up"
+    portmode: access
+    untagged: 249
+    stp:
+      edgeport: true
+      bpduguard: true
   twentyFiveGigE 1/6:
-    state: "down"
+    state: "up"
+    portmode: trunk
+    tagged:
+      - 201
+      - 250
+      - 277
+    stp:
+      edgeport: true
+      bpduguard: true
   twentyFiveGigE 1/7:
-    state: "down"
+    state: "up"
+    portmode: access
+    untagged: 249
+    stp:
+      edgeport: true
+      bpduguard: true
   twentyFiveGigE 1/8:
-    state: "down"
+    state: "up"
+    portmode: trunk
+    tagged:
+      - 201
+      - 250
+      - 277
+    stp:
+      edgeport: true
+      bpduguard: true
   twentyFiveGigE 1/9:
-    state: "down"
+    state: "up"
+    portmode: access
+    untagged: 249
+    stp:
+      edgeport: true
+      bpduguard: true
   twentyFiveGigE 1/10:
-    state: "down"
+    state: "up"
+    portmode: trunk
+    tagged:
+      - 201
+      - 250
+      - 277
+    stp:
+      edgeport: true
+      bpduguard: true
   twentyFiveGigE 1/11:
-    state: "down"
+    state: "up"
+    portmode: access
+    untagged: 250
+    stp:
+      edgeport: true
+      bpduguard: true
   twentyFiveGigE 1/12:
-    state: "down"
+    state: "up"
+    portmode: access
+    untagged: 277
+    stp:
+      edgeport: true
+      bpduguard: true
   twentyFiveGigE 1/13:
     state: "down"
   twentyFiveGigE 1/14:
     state: "down"
   twentyFiveGigE 1/15:
-    state: "down"
+    state: "up"
+    portmode: "trunk"
+    tagged: "all"
+    stp:
+      edgeport: true
+      bpduguard: true
   twentyFiveGigE 1/16:
-    state: "down"
+    state: "up"
+    portmode: "trunk"
+    tagged: "all"
+    stp:
+      edgeport: true
+      bpduguard: true
   twentyFiveGigE 1/17:
-    state: "down"
+    state: "up"
+    portmode: "trunk"
+    tagged: "all"
+    stp:
+      edgeport: true
+      bpduguard: true
   twentyFiveGigE 1/18:
-    state: "down"
+    state: "up"
+    portmode: "trunk"
+    tagged: "all"
+    stp:
+      edgeport: true
+      bpduguard: true
   twentyFiveGigE 1/19:
     state: "down"
   twentyFiveGigE 1/20:
     state: "down"
   twentyFiveGigE 1/21:
-    state: "down"
+    state: "up"
+    portmode: "trunk"
+    tagged: "all"
+    stp:
+      edgeport: true
+      bpduguard: true
   twentyFiveGigE 1/22:
-    state: "down"
+    state: "up"
+    portmode: "trunk"
+    tagged: "all"
+    stp:
+      edgeport: true
+      bpduguard: true
   twentyFiveGigE 1/23:
     state: "down"
   twentyFiveGigE 1/24:
@@ -50,19 +155,39 @@ interfaces:
   twentyFiveGigE 1/25:
     state: "down"
   twentyFiveGigE 1/26:
-    state: "down"
+    state: "up"
+    portmode: "trunk"
+    tagged: "all"
+    stp:
+      edgeport: true
+      bpduguard: true
   twentyFiveGigE 1/27:
-    state: "down"
+    state: "up"
+    portmode: "access"
+    untagged: 204
+    stp:
+      edgeport: true
+      bpduguard: true
   twentyFiveGigE 1/28:
-    state: "down"
+    state: "up"
   twentyFiveGigE 1/29:
-    state: "down"
+    state: "up"
+    portmode: "access"
+    untagged: 204
+    stp:
+      edgeport: true
+      bpduguard: true
   twentyFiveGigE 1/30:
-    state: "down"
+    state: "up"
   twentyFiveGigE 1/31:
-    state: "down"
+    state: "up"
+    portmode: "access"
+    untagged: 204
+    stp:
+      edgeport: true
+      bpduguard: true
   twentyFiveGigE 1/32:
-    state: "down"
+    state: "up"
   twentyFiveGigE 1/33:
     state: "down"
   twentyFiveGigE 1/34:
@@ -88,7 +213,15 @@ interfaces:
   twentyFiveGigE 1/44:
     state: "down"
   twentyFiveGigE 1/45:
-    state: "down"
+    description: "port-channel to SFCORE-MGH-MDA-R6C23-1 eth2/5"
+    state: "up"
+    portmode: "trunk"
+    tagged:
+      - 150
+      - 3800
+      - 3802
+    stp:
+      disabled: true
   twentyFiveGigE 1/46:
     state: "down"
   twentyFiveGigE 1/47:
@@ -100,7 +233,14 @@ interfaces:
     state: "up"
     mtu: 9216
   hundredGigE 1/49:
-    state: "down"
+    fanout:
+      type: "single"
+      speed: "40G"
+  fortyGigE 1/49/1:
+    description: "NFS/DRBD server"
+    state: "up"
+    portmode: "trunk"
+    tagged: "all"
   hundredGigE 1/50:
     state: "down"
   hundredGigE 1/51:

--- a/host_vars/NERC-R8PAC23-SW-TORS/interfaces.yaml
+++ b/host_vars/NERC-R8PAC23-SW-TORS/interfaces.yaml
@@ -152,17 +152,9 @@ interfaces:
       edgeport: true
       bpduguard: true
   twentyFiveGigE 1/15:
-    description: "NERC-LenA100-U39-Openshift-Test"
-    state: "up"
-    mtu: 9216
-    portmode: "hybrid"
-    untagged: 2174
-    tagged:
-      - 2170
-      - 2175
-    stp:
-      edgeport: true
-      bpduguard: true
+    description: "NERC-LenA100-U39"
+    allowlist:
+      - "description"
   twentyFiveGigE 1/16:
     description: "NERC-LenA100-U40-Openshift"
     state: "up"

--- a/host_vars/OCT10-SW-HYB/interfaces.yaml
+++ b/host_vars/OCT10-SW-HYB/interfaces.yaml
@@ -139,7 +139,7 @@ interfaces:
     description: "OCT10-FPGABUILD-OBM"
     state: "up"
     portmode: "access"
-    untagged: 910
+    untagged: 911
     stp:
       edgeport: true
       bpduguard: true

--- a/host_vars/OCT4-SW-TORS/interfaces.yaml
+++ b/host_vars/OCT4-SW-TORS/interfaces.yaml
@@ -34,7 +34,7 @@ interfaces:
     state: "up"
     mtu: 9216
     portmode: "hybrid"
-    untagged: 3803
+    untagged: 127
     tagged:
       - 920
       - 921

--- a/roles/hwinfo/tasks/dell_os9.yaml
+++ b/roles/hwinfo/tasks/dell_os9.yaml
@@ -1,0 +1,19 @@
+---
+# Define OS9 connection parameters
+- name: Define OS9 Connection Parameters
+  ansible.builtin.set_fact:
+    ansible_become: true
+    ansible_become_method: enable
+    ansible_ssh_user: "{{ sw_secret['user'] }}"
+    ansible_ssh_pass: "{{ sw_secret['pass'] }}"
+    ansible_become_pass: "{{ sw_secret['pass'] }}"
+
+- name: Gather serial number
+  dellemc.os9.os9_command:
+    commands:
+      - show inventory | grep "\* 1"
+  register: serial_number
+
+- name: Print serial number
+  ansible.builtin.debug:
+    msg: "{{ serial_number.stdout }}"

--- a/roles/hwinfo/tasks/main.yaml
+++ b/roles/hwinfo/tasks/main.yaml
@@ -1,0 +1,4 @@
+---
+- name: Import Dell OS9 Tasks
+  ansible.builtin.import_tasks: dell_os9.yaml
+  when: ansible_network_os == "dellemc.os9.os9"


### PR DESCRIPTION
This is copying the switch config that is on the existing cisco into our yaml format. Let me know if anything looks off. There's a bunch of settings for native vlans in the trunk. This config doesn't preserve that but as long as the port is tagging on the other end that shouldn't be an issue. That's something I'll add later. Here is the config from the cisco switch:

I didn't copy the configs for the vlan interfaces yet - let me know which of those are still needed. I also only copied the interface configs for the interfaces that are currently up

```
!Command: show running-config interface
!Time: Fri Jul 12 17:15:07 2024

version 7.3(11)N1(1)

interface Vlan1

interface Vlan3
  description "VPC Keepalive Link to SFAGGR-MGH-PODB-R3C19-1"
  no shutdown
  no ip redirects
  ip address 10.2.29.113/30

interface Vlan127
  no shutdown
  no ip redirects
  ip address 129.10.5.2/24
  ip ospf passive-interface
  ip router ospf 1 area 0.3.0.5
  vrrp 13
    priority 110
    address 129.10.5.1
    no shutdown
    exit

interface Vlan150
  no shutdown
  no ip redirects
  ip address 10.2.29.126/30
  ip router ospf 1 area 0.3.0.5

interface Vlan204

interface Vlan250
  no shutdown
  no ip redirects
  ip address 192.168.24.2/24
  ip ospf passive-interface
  vrrp 10
    priority 110
    address 192.168.24.1
    no shutdown
    exit

interface Vlan251
  description "P2P Connection between MOC-NEU-PODB-R3C19-1 to MOC-NEU-PODB-R3C17-1"
  no shutdown
  mtu 9216
  no ip redirects
  ip address 10.2.29.121/30
  ip router ospf 1 area 0.3.0.5

interface Vlan930
  no shutdown
  ip address 10.80.2.102/20

interface Vlan3800
  no shutdown
  no ip redirects
  ip address 192.168.192.11/24

interface Ethernet1/1
  description "Kaizen Compute"
  switchport access vlan 249

interface Ethernet1/2
  description "Kaizen Compute"
  switchport mode trunk
  switchport trunk native vlan 277
  switchport trunk allowed vlan 201,250,277
  spanning-tree port type edge trunk

interface Ethernet1/3
  description "Kaizen Compute"
  switchport access vlan 249

interface Ethernet1/4
  description "Kaizen Compute"
  switchport mode trunk
  switchport trunk native vlan 277
  switchport trunk allowed vlan 201,250,277
  spanning-tree port type edge trunk

interface Ethernet1/5
  description "Kaizen Compute"
  switchport access vlan 249

interface Ethernet1/6
  description "Kaizen Compute"
  switchport mode trunk
  switchport trunk native vlan 277
  switchport trunk allowed vlan 201,250,277
  spanning-tree port type edge trunk

interface Ethernet1/7
  description "Kaizen Compute"
  switchport access vlan 249

interface Ethernet1/8
  description "Kaizen Compute"
  switchport mode trunk
  switchport trunk native vlan 277
  switchport trunk allowed vlan 201,250,277
  spanning-tree port type edge trunk

interface Ethernet1/9
  description "Kaizen Compute"
  switchport access vlan 249

interface Ethernet1/10
  description "Kaizen Compute"
  switchport mode trunk
  switchport trunk native vlan 277
  switchport trunk allowed vlan 201,250,277
  spanning-tree port type edge trunk

interface Ethernet1/11
  description "Mass computing Cluster CISCO"
  switchport access vlan 250

interface Ethernet1/12
  description "Mass computing Cluster CISCO"
  switchport access vlan 277

interface Ethernet1/13
  description "Mass computing Cluster CISCO"
  switchport mode trunk
  switchport trunk native vlan 201
  switchport trunk allowed vlan 201,250,1004

interface Ethernet1/14
  description "Mass computing Cluster CISCO"
  switchport mode trunk
  switchport trunk native vlan 201
  switchport trunk allowed vlan 201,250,1004

interface Ethernet1/15
  switchport mode trunk

interface Ethernet1/16
  switchport mode trunk
  switchport trunk native vlan 127

interface Ethernet1/17
  description "Mass computing Cluster CISCO"
  switchport mode trunk

interface Ethernet1/18
  description "Mass computing Cluster CISCO"
  switchport mode trunk
  switchport trunk native vlan 127

interface Ethernet1/19
  description "Mass computing Cluster CISCO"
  switchport mode trunk
  switchport trunk native vlan 315
  switchport trunk allowed vlan 315
  spanning-tree port type edge trunk

interface Ethernet1/20
  description "Mass computing Cluster CISCO"
  switchport mode trunk
  switchport trunk native vlan 500
  switchport trunk allowed vlan 500
  spanning-tree port type edge trunk

interface Ethernet1/21
  description "Kaizen Network Controller 2"
  switchport mode trunk

interface Ethernet1/22
  description "Kaizen Network Controller 2"
  switchport mode trunk

interface Ethernet1/23
  description "Kaizen GPU2 compute"
  switchport mode trunk
  switchport trunk native vlan 4093
  switchport trunk allowed vlan none
  spanning-tree port type edge trunk

interface Ethernet1/24
  description "Kaizen GPU2 compute"
  switchport mode trunk
  switchport trunk native vlan 277
  switchport trunk allowed vlan 277
  spanning-tree port type edge trunk

interface Ethernet1/25
  switchport mode trunk
  switchport trunk native vlan 930

interface Ethernet1/26
  switchport mode trunk
  switchport trunk native vlan 930

interface Ethernet1/27
  description oct-41-1
  switchport access vlan 204

interface Ethernet1/28
  description oct-41-2
  no switchport

interface Ethernet1/29
  description oct-43-1
  switchport access vlan 204

interface Ethernet1/30
  description oct-43-2
  no switchport

interface Ethernet1/31
  description oct-45-1
  switchport access vlan 204

interface Ethernet1/32
  description oct-45-2
  no switchport

interface Ethernet1/33
  description "Fujitsu 17-17 nic1"
  switchport access vlan 930
  speed 1000

interface Ethernet1/34
  description "OSD2 nic2"
  switchport access vlan 930
  speed 1000

interface Ethernet1/35
  switchport access vlan 930
  speed 1000

interface Ethernet1/36
  switchport access vlan 930
  speed 1000

interface Ethernet1/37
  switchport access vlan 999
  spanning-tree port type edge trunk

interface Ethernet1/38
  switchport access vlan 999
  spanning-tree port type edge trunk

interface Ethernet1/39
  switchport access vlan 999
  spanning-tree port type edge trunk

interface Ethernet1/40
  switchport access vlan 999
  spanning-tree port type edge trunk

interface Ethernet1/41
  description "Keepalive Link SFAGGR-MGH-PODA-R3C19-1 1/41"
  switchport mode trunk

interface Ethernet1/42
  description "Keepalive Link SFAGGR-MGH-PODA-R3C19-1 1/42"
  switchport mode trunk

interface Ethernet1/43
  switchport mode trunk

interface Ethernet1/44
  switchport mode trunk

interface Ethernet1/45
  switchport access vlan 999

interface Ethernet1/46
  switchport access vlan 999

interface Ethernet1/47
  switchport access vlan 930

interface Ethernet1/48
  description "port-channel to SFCORE-MGH-MDA-R6C23-1 eth2/5"
  switchport mode trunk
  switchport trunk allowed vlan 150,3800,3802

interface Ethernet2/1
  description "cache-server-17-41-nic2"
  switchport mode trunk
  switchport trunk native vlan 204
  switchport trunk allowed vlan 204,267,280

interface Ethernet2/2
  description "cache-server-17-41-nic1"
  switchport mode trunk
  switchport trunk native vlan 277
  switchport trunk allowed vlan 252,277,306,625

interface Ethernet2/3
  description NFS/DRBD server
  switchport mode trunk
  switchport trunk native vlan 201

interface Ethernet2/4
  description temp-to-other-cisco
  switchport mode trunk

interface Ethernet2/5
  no lldp transmit
  no lldp receive
  switchport mode trunk
  switchport trunk native vlan 201

interface Ethernet2/6
  switchport mode trunk

interface mgmt0
  vrf member management
  ip address 10.0.17.42/19

interface loopback0
  ip address 10.2.2.1/32
  ip ospf advertise-subnet
  ip router ospf 1 area 0.3.0.5
```