### PR TITLE
Add vlan 911 to the esi controllers.

### DIFF
--- a/host_vars/MOC-CORE-2/interfaces.yaml
+++ b/host_vars/MOC-CORE-2/interfaces.yaml
@@ -7,6 +7,8 @@ interfaces:
     description: "MOCINFRA-CTRL-U36-R"
     state: "up"
     untagged: 127
+    tagged:
+      - 911
     mtu: 9216
     portmode: "hybrid"
     stp:
@@ -16,6 +18,8 @@ interfaces:
     description: "MOCINFRA-CTRL-U35-R"
     state: "up"
     untagged: 127
+    tagged:
+      - 911
     mtu: 9216
     portmode: "hybrid"
     stp:
@@ -25,6 +29,8 @@ interfaces:
     description: "MOCINFRA-CTRL-U34-R"
     state: "up"
     untagged: 127
+    tagged:
+      - 911
     mtu: 9216
     portmode: "hybrid"
     stp:


### PR DESCRIPTION
This is an ipmi/management network and I am testing to see if I can pass this to a pod/VM on the moc-infra cluster.

I manually made the change on the switches.