### PR TITLE
Add new management vlan to the moc-infra controllers

### DIFF
--- a/host_vars/MOC-CORE-2/interfaces.yaml
+++ b/host_vars/MOC-CORE-2/interfaces.yaml
@@ -8,6 +8,7 @@ interfaces:
     state: "up"
     untagged: 127
     tagged:
+      - 215
       - 911
       - 912
       - 913
@@ -21,6 +22,7 @@ interfaces:
     state: "up"
     untagged: 127
     tagged:
+      - 215
       - 911
       - 912
       - 913
@@ -34,6 +36,7 @@ interfaces:
     state: "up"
     untagged: 127
     tagged:
+      - 215
       - 911
       - 912
       - 913


### PR DESCRIPTION
Once I've migrated the stuff to this new network, we can remove the ipmi vlans 91*.