### PR TITLE
Remove vlan 912 and 913 from moc-infra

### DIFF
--- a/host_vars/MOC-CORE-2/interfaces.yaml
+++ b/host_vars/MOC-CORE-2/interfaces.yaml
@@ -10,8 +10,6 @@ interfaces:
     tagged:
       - 215
       - 911
-      - 912
-      - 913
     mtu: 9216
     portmode: "hybrid"
     stp:
@@ -24,8 +22,6 @@ interfaces:
     tagged:
       - 215
       - 911
-      - 912
-      - 913
     mtu: 9216
     portmode: "hybrid"
     stp:
@@ -38,8 +34,6 @@ interfaces:
     tagged:
       - 215
       - 911
-      - 912
-      - 913
     mtu: 9216
     portmode: "hybrid"
     stp:


### PR DESCRIPTION
We now use vlan215 to get to those. Vlan 911 stays because the lenovo VM is still consuming it.