### PR TITLE
These seem to be the only ovirt ports managed here so shutting them

### DIFF
--- a/host_vars/MOC-R4PAC02-SW-MGMT/interfaces.yaml
+++ b/host_vars/MOC-R4PAC02-SW-MGMT/interfaces.yaml
@@ -48,29 +48,11 @@ interfaces:
       edgeport: true
       bpduguard: true
   GigabitEthernet 1/7:
-    description: "OVIRT-U14"
-    state: "up"
-    portmode: "access"
-    untagged: 912
-    stp:
-      edgeport: true
-      bpduguard: true
+    state: "down"
   GigabitEthernet 1/8:
-    description: "OVIRT-U15"
-    state: "up"
-    portmode: "access"
-    untagged: 912
-    stp:
-      edgeport: true
-      bpduguard: true
+    state: "down"
   GigabitEthernet 1/9:
-    description: "OVIRT-U16"
-    state: "up"
-    portmode: "access"
-    untagged: 912
-    stp:
-      edgeport: true
-      bpduguard: true
+    state: "down"
   GigabitEthernet 1/10:
     description: "U24"
     state: "up"

--- a/host_vars/MOC-R4PAC04-SW-MGMT/interfaces.yaml
+++ b/host_vars/MOC-R4PAC04-SW-MGMT/interfaces.yaml
@@ -56,29 +56,11 @@ interfaces:
       edgeport: true
       bpduguard: true
   GigabitEthernet 1/8:
-    description: "OVIRT-U15"
-    state: "up"
-    portmode: "access"
-    untagged: 912
-    stp:
-      edgeport: true
-      bpduguard: true
+    state: "down"
   GigabitEthernet 1/9:
-    description: "OVIRT-U16"
-    state: "up"
-    portmode: "access"
-    untagged: 912
-    stp:
-      edgeport: true
-      bpduguard: true
+    state: "down"
   GigabitEthernet 1/10:
-    description: "OVIRT-NAS-U17"
-    state: "up"
-    portmode: "access"
-    untagged: 912
-    stp:
-      edgeport: true
-      bpduguard: true
+    state: "down"
   GigabitEthernet 1/11:
     state: "down"
   GigabitEthernet 1/12:


### PR DESCRIPTION
down now that ovirt is off.

@hakasapl Can you turn off the other switchports not managed by this repo?