### PR TITLE
Add vlan 204 to the infra cluster

### DIFF
--- a/host_vars/MOC-CORE-2/interfaces.yaml
+++ b/host_vars/MOC-CORE-2/interfaces.yaml
@@ -8,6 +8,7 @@ interfaces:
     state: "up"
     untagged: 127
     tagged:
+      - 204
       - 215
       - 911
     mtu: 9216
@@ -20,6 +21,7 @@ interfaces:
     state: "up"
     untagged: 127
     tagged:
+      - 204
       - 215
       - 911
     mtu: 9216
@@ -32,6 +34,7 @@ interfaces:
     state: "up"
     untagged: 127
     tagged:
+      - 204
       - 215
       - 911
     mtu: 9216


### PR DESCRIPTION
I want to run some pxe server or maybe maas on this network for the occasional chance we need to provision an OS on a machine and I hate the slow virtual console so much.